### PR TITLE
🐛 truncate termination log file

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -747,7 +747,7 @@ fn resolve_tokenizer_path(model_name: &str, revision: Option<&str>) -> Result<St
 fn write_termination_log(msg: &str) -> Result<(), io::Error> {
     // Writes a message to the termination log.
     // Creates the logfile if it doesn't exist.
-    let mut f = File::options().write(true).create(true).open("/dev/termination-log")?;
+    let mut f = File::options().write(true).create(true).truncate(true).open("/dev/termination-log")?;
     writeln!(f, "{}", msg)?;
     Ok(())
 }

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -188,7 +188,7 @@ fn validate_args(args: &Args) {
 fn write_termination_log(msg: &str) -> Result<(), io::Error> {
     // Writes a message to the termination log.
     // Creates the logfile if it doesn't exist.
-    let mut f = File::options().write(true).create(true).open("/dev/termination-log")?;
+    let mut f = File::options().write(true).create(true).truncate(true).open("/dev/termination-log")?;
     writeln!(f, "{}", msg)?;
     Ok(())
 }


### PR DESCRIPTION
#### Motivation

Multiple restarts and crashes of a TGIS container on a k8s pod can show multiple errors (or usually, multiple lines of the same error) in `/dev/termination-log`

#### Modifications

This change truncates the termination log before writing so only the cause of the current container crash is shown

#### Result

Better pod termination reasons in k8s statuses

