### PR TITLE
feat: allow configuration of the max soft prompt length

### DIFF
--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -559,7 +559,7 @@ class CausalLM(Model):
             model_path, AutoModelForCausalLM, dtype, quantize, model_config, max_sequence_length
         )
 
-        super(CausalLM, self).__init__(inference_engine, dtype)
+        super(CausalLM, self).__init__(inference_engine, dtype, max_sequence_length)
 
         if self.model.config.pad_token_id is not None:
             self.tokenizer.pad_token_id = self.model.config.pad_token_id

--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -385,7 +385,7 @@ class FlashCausalLM(Model):
             model_path, auto_model_class, dtype, quantize, model_config, max_sequence_length
         )
 
-        super(FlashCausalLM, self).__init__(inference_engine, dtype)
+        super(FlashCausalLM, self).__init__(inference_engine, dtype, max_sequence_length)
         self.use_position_ids = True
 
         if self.model.config.pad_token_id is not None:

--- a/server/text_generation_server/models/seq2seq_lm.py
+++ b/server/text_generation_server/models/seq2seq_lm.py
@@ -557,7 +557,7 @@ class Seq2SeqLM(Model):
         inference_engine = get_inference_engine_class(deployment_framework)(
             model_path, AutoModelForSeq2SeqLM, dtype, quantize, model_config, max_sequence_length
         )
-        super(Seq2SeqLM, self).__init__(inference_engine, dtype)
+        super(Seq2SeqLM, self).__init__(inference_engine, dtype, max_sequence_length)
 
         bos_token_id = self.model.config.decoder_start_token_id
         if bos_token_id is None:


### PR DESCRIPTION
#### Motivation

The PrefixCache has a max_length parameter that configures the max virtual tokens of prompts. It is currently hard-coded to 256 with a TODO in the code to make it configurable. This causes problems when users tune prompts on more than 256 virtual tokens.

#### Modifications

instead of defaulting to a hard-coded 256, the default soft prompt length is now 50% of the max sequence length
the env var MAX_PROMPT_PREFIX_LENGTH can be used to override this default if desired

#### Result

Inference now works as expected as long as the prefix lengths are <50% of max sequence length
