### PR TITLE
Also convert .index.json file

### DIFF
--- a/server/tests/utils/test_convert.py
+++ b/server/tests/utils/test_convert.py
@@ -13,7 +13,7 @@ def test_convert_files():
     local_pt_files = download_weights(model_id, extension=".bin")
     local_pt_files = [Path(p) for p in local_pt_files]
     local_st_files = [
-        p.parent / f"{p.stem.lstrip('pytorch_')}.safetensors" for p in local_pt_files
+        p.parent / f"{p.stem.removeprefix('pytorch_')}.safetensors" for p in local_pt_files
     ]
     convert_files(local_pt_files, local_st_files, discard_names=[])
 

--- a/server/text_generation_server/utils/__init__.py
+++ b/server/text_generation_server/utils/__init__.py
@@ -1,4 +1,4 @@
-from text_generation_server.utils.convert import convert_file, convert_files
+from text_generation_server.utils.convert import convert_file, convert_files, convert_index_file
 from text_generation_server.utils.dist import (
     initialize_torch_distributed,
     run_rank_n,
@@ -10,6 +10,7 @@ from text_generation_server.utils.weights import Weights
 from text_generation_server.utils.hub import (
     get_model_path,
     local_weight_files,
+    local_index_files,
     weight_files,
     weight_hub_files,
     download_weights,
@@ -41,6 +42,7 @@ from text_generation_server.utils.memory_characterizer import (
 __all__ = [
     "convert_file",
     "convert_files",
+    "convert_index_file",
     "initialize_torch_distributed",
     "run_rank_n",
     "print_rank_n",
@@ -48,6 +50,7 @@ __all__ = [
     "RANK",
     "get_model_path",
     "local_weight_files",
+    "local_index_files",
     "weight_files",
     "weight_hub_files",
     "download_weights",

--- a/server/text_generation_server/utils/hub.py
+++ b/server/text_generation_server/utils/hub.py
@@ -100,3 +100,9 @@ def local_weight_files(model_path: str, extension=".safetensors"):
     """Get the local safetensors filenames"""
     ext = "" if extension is None else extension
     return glob.glob(f"{model_path}/*{ext}")
+
+
+def local_index_files(model_path: str, extension=".safetensors"):
+    """Get the local .index.json filename"""
+    ext = "" if extension is None else extension
+    return glob.glob(f"{model_path}/*{ext}.index.json")


### PR DESCRIPTION
#### Motivation

The conversion to safetensors wasn't taking into account the pytorch_model.bin.index.json file that needs to be converted to model.safetensors.index.json.

#### Modifications

Also converts `bin.index.json` files
