### PR TITLE
Fix OOM due to large prompt cache

### DIFF
--- a/router/src/batch_types.rs
+++ b/router/src/batch_types.rs
@@ -32,7 +32,7 @@ pub(crate) trait BatchType: Send + Sync + Clone + 'static {
                 let generated_count = entry.generated_tokens;
                 Self::update_stats(
                     &stats,
-                    entry.input_length + generated_count as usize,
+                    entry.input_length + entry.prefix_length + generated_count as usize,
                     (entry.request.parameters.max_new_tokens - generated_count) as usize,
                 )
             }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -91,7 +91,7 @@ async fn generate(
     // Validate request
     //let details = req.0.parameters.details;
     let GenerateRequest {inputs, prefix_id, parameters} = req.0;
-    let (input_length, validated_request) =
+    let (request_size, validated_request) =
         state.validation.validate(
             prefix_id, parameters, vec![inputs]
         ).await.map_err(|err| {
@@ -102,7 +102,7 @@ async fn generate(
     // Inference
     let response = state
         .batcher
-        .infer(input_length, validated_request)
+        .infer(request_size.input_length, request_size.prefix_length, validated_request)
         .await
         .map_err(|err| {
             tracing::error!("{err}");

--- a/server/tests/test_prompt_cache.py
+++ b/server/tests/test_prompt_cache.py
@@ -23,24 +23,31 @@ REPO_ROOT = os.path.dirname(os.path.dirname(TESTS_DIR))
 INTEGRATION_TESTS_DIR = os.path.join(REPO_ROOT, "integration_tests")
 
 
+@pytest.fixture(autouse=True)
+def temp_prompt_store(tmp_path):
+    # Unless overriden by another fixture, sets the prefix store path to some temp dir
+    with patch("text_generation_server.prompt_cache.PREFIX_STORE_PATH", tmp_path):
+        yield
+
+
 @pytest.fixture()
-def temp_prompt_store():
+def integration_test_prompts():
     with patch("text_generation_server.prompt_cache.PREFIX_STORE_PATH", Path(os.path.join(INTEGRATION_TESTS_DIR, "prompt_prefixes"))):
         yield
 
 
 @pytest.fixture()
-def tiny_starcoder_decoder_prompt(temp_prompt_store):
+def tiny_starcoder_decoder_prompt(integration_test_prompts):
     return "tiny_starcoder"
 
 
 @pytest.fixture()
-def tiny_raw_llama_peft_adapter_prompt(temp_prompt_store):
+def tiny_raw_llama_peft_adapter_prompt(integration_test_prompts):
     return "tinyllama_peft_adapter_raw"
 
 
 @pytest.fixture()
-def tiny_llama_peft_adapter_prompt(temp_prompt_store):
+def tiny_llama_peft_adapter_prompt(integration_test_prompts):
     return "tinyllama_peft_adapter"
 
 

--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -25,7 +25,7 @@ def serve(
     max_sequence_length: int = 2048,
     max_new_tokens: int = 1024,
     max_batch_size: int = 12,
-    batch_safety_margin: int = 20,
+    batch_safety_margin: int = typer.Option(20, help="Integer from 0-100, a percentage of free GPU memory to hold back as a safety margin to avoid OOM"),
     revision: Optional[str] = None,
     sharded: bool = False,
     cuda_process_memory_fraction: float = 1.0,

--- a/server/text_generation_server/models/model.py
+++ b/server/text_generation_server/models/model.py
@@ -10,6 +10,7 @@ from typing import List, Tuple, Optional, TypeVar, Type
 
 from transformers import PreTrainedModel
 
+import text_generation_server.prompt_cache
 from text_generation_server.models.types import Batch, GenerateError
 from text_generation_server.inference_engine.engine import BaseInferenceEngine
 from text_generation_server.pb import generate_pb2
@@ -44,7 +45,8 @@ class Model(ABC):
         # Check whether model supports position_ids
         self.use_position_ids = "position_ids" in inspect.signature(self.model.forward).parameters
 
-        prompt_prefix_supported = self._setup_prompt_encoder()
+        # Short-circuit: Don't set up the prompt encoder if the prompt cache is not set
+        prompt_prefix_supported = self.prompt_cache_set() and self._setup_prompt_encoder()
 
         if prompt_prefix_supported:
             # Set up prefix cache
@@ -183,6 +185,10 @@ class Model(ABC):
             if r.id != next_id:
                 next_batch_keep_indices.append(i)
         return next_batch_keep_indices
+
+    @staticmethod
+    def prompt_cache_set() -> bool:
+        return text_generation_server.prompt_cache.PREFIX_STORE_PATH is not None
 
     def _setup_prompt_encoder(self) -> bool:
         try:

--- a/server/text_generation_server/prompt_cache.py
+++ b/server/text_generation_server/prompt_cache.py
@@ -9,7 +9,8 @@ from safetensors.torch import load_file as safe_load_file
 
 import torch
 
-PREFIX_STORE_PATH = Path(os.getenv("PREFIX_STORE_PATH", "prompt_prefixes"))
+_PREFIX_STORE_PATH_STR = os.getenv("PREFIX_STORE_PATH", None)
+PREFIX_STORE_PATH = Path(_PREFIX_STORE_PATH_STR) if _PREFIX_STORE_PATH_STR else None
 
 VALID_PREFIX_ID_PATTERN = re.compile("[/\\w\\-]+")
 PROMPT_CACHE_SIZE_MB = int(os.getenv("PROMPT_CACHE_SIZE_MB", "512"))


### PR DESCRIPTION
#### Motivation

OOM errors could be caused either by filling up the prefix cache with prefixes, or by sending large amounts of requests with very large prefixes.

#### Modifications

This handles the OOM problem with large prefixes by both:
- Taking the max prefix cache size into account when running the memory usage estimator, to ensure a full prefix cache does not cause an OOM
- Taking the prefix length into consideration when deciding if a request will fit into a batch, to avoid large prefixes causing unexpected large memory allocations

This includes an **api breaking change to the config**, as the prefix cache will not be enabled unless a user explicitly sets PREFIX_STORE_PATH to some non-empty value.

#### Result

It is now not easy to cause an OOM by loading TGIS with requests for many different prefixes, nor requests with large prefixes.

#### Related Issues
