### PR TITLE
ci: Cleanup old build cache images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ defaults:
 env:
   CI: true
   SERVER_IMAGE_NAME: "text-gen-server:0"
+  SERVER_IMAGE: "ghcr.io/ibm/text-gen-server:latest"  # TODO: consider publishing to quay.io or icr.io instead
 
 jobs:
   build:
@@ -35,7 +36,6 @@ jobs:
     env:
       CACHE_IMAGE: "ghcr.io/ibm/text-gen-server:build-cache"
       CACHE_REGISTRY: "ghcr.io"
-      SERVER_IMAGE: "ghcr.io/ibm/text-gen-server:latest"
       
     steps:
       - name: "Checkout"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - cleanup_build_cache
     paths-ignore:
       - "**.md"
       - "proto/**"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
       
       - name: "Cleanup old cache images"
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
+        if: ${{ github.event_name == 'push' }}
         with: 
           package-name: 'text-gen-server'
           package-type: 'container'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
     env:
       CACHE_IMAGE: "ghcr.io/ibm/text-gen-server:build-cache"
       CACHE_REGISTRY: "ghcr.io"
+      CACHE_PACKAGE_NAME: "text-gen-server"
       
     steps:
       - name: "Checkout"
@@ -92,9 +93,9 @@ jobs:
         uses: actions/delete-package-versions@v5
         if: ${{ github.event_name == 'push' }}
         with: 
-          package-name: 'text-gen-server'
-          package-type: 'container'
-          delete-only-untagged-versions: 'true'
+          package-name: ${{ env.CACHE_PACKAGE_NAME }}
+          package-type: container
+          delete-only-untagged-versions: true
 
       - name: "List docker images"
         run: docker images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - cleanup_build_cache
     paths-ignore:
       - "**.md"
       - "proto/**"
@@ -34,8 +35,8 @@ jobs:
     env:
       CACHE_IMAGE: "ghcr.io/ibm/text-gen-server:build-cache"
       CACHE_REGISTRY: "ghcr.io"
-      SERVER_IMAGE: "ghcr.io/ibm/text-gen-server:latest"  # TODO: don't push final image as a package to ghcr.io
-
+      SERVER_IMAGE: "ghcr.io/ibm/text-gen-server:latest"
+      
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -86,6 +87,13 @@ jobs:
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}
           cache-to: ${{ env.CACHE_TO }}
           push: ${{ github.event_name != 'pull_request' }}
+      
+      - name: "Cleanup old cache images"
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'text-gen-server'
+          package-type: 'container'
+          delete-only-untagged-versions: 'true'
 
       - name: "List docker images"
         run: docker images


### PR DESCRIPTION
#### Motivation

Every successful push to main produces new build cache images on ghcr.io which have to be cleaned up manually.

#### Modifications

Add `actions/delete-package-versions` after successful push of a new cache image (implicit)

#### Result

Removed all 75 old untagged package versions

#### Related Issues

#12 
#38 
