### PR TITLE
ci: Push text-gen-server release images to Quay.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,9 +77,6 @@ jobs:
           fi
           echo "CACHE_TO=$CACHE_TO" >> $GITHUB_ENV
 
-          # TODO: remove this
-          env | sort
-
       # generate tags: quay.io/wxpe/text-gen-server:f73d9aa, quay.io/wxpe/text-gen-server:main, quay.io/wxpe/text-gen-server:main.f73d9aa
       - name: "Generate tags"
         id: meta
@@ -92,6 +89,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,enable=true,priority=100,prefix=,suffix=,format=short     
+            type=sha,enable=true,priority=100,prefix=${{ env.GITHUB_REF_NAME }},suffix=,format=short     
 
       - name: "Docker build server-release"
         uses: docker/build-push-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - quay
     paths-ignore:
       - "**.md"
       - "proto/**"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - quay
     paths-ignore:
       - "**.md"
       - "proto/**"
@@ -22,9 +23,7 @@ defaults:
     shell: bash
 
 env:
-  CI: true
-  SERVER_IMAGE_NAME: "text-gen-server:0"
-  SERVER_IMAGE: "ghcr.io/ibm/text-gen-server:latest"  # TODO: consider publishing to quay.io or icr.io instead
+  SERVER_IMAGE: "ghcr.io/ibm/text-gen-server"  # TODO: publishing to quay.io
 
 jobs:
   build:
@@ -78,12 +77,28 @@ jobs:
           fi
           echo "CACHE_TO=$CACHE_TO" >> $GITHUB_ENV
 
+          # TODO: remove this
+          env | sort
+
+      # generate tags: quay.io/wxpe/text-gen-server:f73d9aa, quay.io/wxpe/text-gen-server:main, quay.io/wxpe/text-gen-server:main.f73d9aa
+      - name: "Generate tags"
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.SERVER_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=short     
+
       - name: "Docker build server-release"
         uses: docker/build-push-action@v5
         with:
           context: .
           target: server-release
-          tags: ${{ env.SERVER_IMAGE }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}
           cache-to: ${{ env.CACHE_TO }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ defaults:
     shell: bash
 
 env:
-  SERVER_IMAGE: "ghcr.io/ibm/text-gen-server"  # TODO: publishing to quay.io
+  SERVER_IMAGE: "quay.io/wxpe/text-gen-router"
+  IMAGE_REGISTRY: "quay.io"
 
 jobs:
   build:
@@ -49,7 +50,14 @@ jobs:
       - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
 
-      - name: "Log in to cache image container registry"
+      - name: "Log in to container registry (server-release)"
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.WXPE_QUAY_USER }}
+          password: ${{ secrets.WXPE_QUAY_TOKEN }}
+
+      - name: "Log in to container registry (cache image)"
         uses: docker/login-action@v3
         with:
           registry: ${{ env.CACHE_REGISTRY }}
@@ -77,7 +85,6 @@ jobs:
           fi
           echo "CACHE_TO=$CACHE_TO" >> $GITHUB_ENV
 
-      # generate tags: quay.io/wxpe/text-gen-server:f73d9aa, quay.io/wxpe/text-gen-server:main, quay.io/wxpe/text-gen-server:main.f73d9aa
       - name: "Generate tags"
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,enable=true,priority=100,prefix=,suffix=,format=short     
-            type=sha,enable=true,priority=100,prefix=${{ env.GITHUB_REF_NAME }},suffix=,format=short     
+            type=sha,enable=true,priority=100,prefix=${{ github.ref_name }}.,suffix=,format=short     
 
       - name: "Docker build server-release"
         uses: docker/build-push-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ defaults:
     shell: bash
 
 env:
-  SERVER_IMAGE: "quay.io/wxpe/text-gen-router"
+  SERVER_IMAGE: "quay.io/wxpe/text-gen-server"
   IMAGE_REGISTRY: "quay.io"
 
 jobs:


### PR DESCRIPTION
#### Motivation

Server release images need a container registry home.

#### Modifications

Push to quay.io instead of ghcr.io

#### Result

Images pushed to quay.io

https://quay.io/repository/wxpe/text-gen-server?tab=tags

#### Related Issues

N/A

@joerunde 
