### PR TITLE
fix CUDA OOM error when loading large models for hf_transformers engine

### DIFF
--- a/server/text_generation_server/inference_engine/hf_transformers.py
+++ b/server/text_generation_server/inference_engine/hf_transformers.py
@@ -72,7 +72,11 @@ class InferenceEngine(BaseInferenceEngine):
         if slow_but_exact:
             kwargs["slow_but_exact"] = True
 
+
         with self.device:
-            self.model = model_class.from_pretrained(**kwargs).requires_grad_(False).eval()
+            self.model = model_class.from_pretrained(
+                    low_cpu_mem_usage=True,
+                    **kwargs,
+            ).requires_grad_(False).eval()
             # This seems to be necessary even with with self.device
             self.model.to(self.device)


### PR DESCRIPTION
using `low_cpu_mem_usage=True` memory usage when loading large models is lowered.

See https://huggingface.co/docs/transformers/main_classes/model#large-model-loading for more context

https://issues.redhat.com/browse/RHOAIENG-2502