### PR TITLE
Update launcher to auto-convert fast tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,12 +927,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "mach2"
@@ -2034,6 +2031,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -2444,11 +2442,12 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
+ "rand",
 ]
 
 [[package]]

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -12,4 +12,4 @@ nix = "0.27.1"
 serde_json = "^1.0.114"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
-
+uuid = { version = "1.7.0", features = ["v4", "fast-rng"] }


### PR DESCRIPTION
This PR updates the launcher to save the fast tokenizer to `/tmp/<uuid>/tokenizer.json` for use by the router, in case the model does not have an already converted fast tokenizer or the one it has isn't in sync with its slow tokenizer.