### PR TITLE
:bug: disallow downloads for fast tokenizer conversion

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -828,7 +828,7 @@ fn save_fast_tokenizer(
         format!(
             "from transformers import AutoTokenizer; \
             AutoTokenizer.from_pretrained(\"{model_name}\", \
-            revision=\"{revision}\").save_pretrained(\"{save_path}\")"
+            revision=\"{revision}\", local_files_only=True).save_pretrained(\"{save_path}\")"
         )
     } else {
         format!(


### PR DESCRIPTION
#### Motivation

Some of our models are failing internal integration tests where the AutoTokenizer tries to download files even though they exist locally in the cache.

#### Modifications

This adds the `local_files_only` kwarg to the `.from_pretrained()` call in the fast tokenizer conversion in the launcher, to prevent hf from attempting to download tokenizer files

#### Result

Local tests show this allows the failing models to successfully load up tokenizers
