### PR TITLE
fix: small improvement to convert-to-safetensors

### DIFF
--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -166,6 +166,7 @@ def convert_to_safetensors(
         config = transformers.AutoConfig.from_pretrained(
             model_name,
             revision=revision,
+            trust_remote_code=utils.TRUST_REMOTE_CODE
         )
         architecture = config.architectures[0]
 
@@ -184,7 +185,7 @@ def convert_to_safetensors(
         local_st_index_file = local_pt_index_file.parent / f"{st_prefix}.safetensors.index.json"
 
         if os.path.exists(local_st_index_file):
-            print("Existing .safetensors.index.json file found, remove it first to reconvert")
+            print("Existing model.safetensors.index.json file found, remove it first to reconvert")
             return
 
         utils.convert_index_file(local_pt_index_file, local_st_index_file, local_pt_files, local_st_files)


### PR DESCRIPTION
When running `text-generation-server convert-to-safetensors ./` on a local download of model files that have some remote code files, the `AutoConfig.from_pretrained()` call prints an interactive prompt:
```
The repository for ./ contains custom code which must be executed to correctly load the model. You can inspect the repository content at https://hf.co/./.
You can avoid this prompt in future by passing the argument `trust_remote_code=True`.

Do you wish to run the custom code? [y/N]
```

This PR enables the command to be executed non-interactively in this case. TRUST_REMOTE_CODE defaults to true.

Also made a small fix to a log message printed if the index file already exists to include the full name.