### PR TITLE
Fix the forwarding of the length penalty parameter

### DIFF
--- a/integration_tests/test_cases_bloom560m.yaml
+++ b/integration_tests/test_cases_bloom560m.yaml
@@ -1254,7 +1254,7 @@
 
 
 # Length penalty
-- name: Length penalty
+- name: Length penalty with repetition penalty
   request:
     params:
       decoding:
@@ -1273,6 +1273,24 @@
         stopReason: EOS_TOKEN
         text: The first time I saw the movie, it was in
 
+# Length penalty
+- name: Length penalty
+  request:
+    params:
+      decoding:
+        length_penalty:
+          start_index: 8
+          decay_factor: 1.01
+      stopping:
+        maxNewTokens: 20
+    requests:
+      - {"text": "A very long story:\n"}
+  response:
+    responses:
+      - generatedTokenCount: 12
+        inputTokenCount: 6
+        stopReason: EOS_TOKEN
+        text: The first time I saw the movie, I was a
 
 # Multiple inputs
 - name: Multiple inputs

--- a/integration_tests/test_cases_mt0small.yaml
+++ b/integration_tests/test_cases_mt0small.yaml
@@ -1166,7 +1166,7 @@
 
 
 # Length penalty
-- name: Length penalty
+- name: Length penalty with repetition penalty
   request:
     params:
       decoding:
@@ -1186,6 +1186,24 @@
         text: The very long story is
 
 
+# Length penalty
+- name: Length penalty
+  request:
+    params:
+      decoding:
+        length_penalty:
+          start_index: 3
+          decay_factor: 4.0
+      stopping:
+        maxNewTokens: 20
+    requests:
+      - {"text": "A very long story:\n"}
+  response:
+    responses:
+      - generatedTokenCount: 7
+        inputTokenCount: 8
+        stopReason: EOS_TOKEN
+        text: The very long story is
 
 # Multiple inputs
 - name: Multiple inputs

--- a/router/src/grpc_server.rs
+++ b/router/src/grpc_server.rs
@@ -549,7 +549,6 @@ fn convert_params(
                 gp.length_penalty =
                     d.length_penalty.map(|lp| (lp.start_index, lp.decay_factor));
             }
-
             // Stopping Criteria
             if let Some(s) = p.stopping {
                 if s.max_new_tokens != 0 {

--- a/router/src/grpc_server.rs
+++ b/router/src/grpc_server.rs
@@ -545,10 +545,11 @@ fn convert_params(
             if let Some(d) = p.decoding {
                 if d.repetition_penalty != 0.0 {
                     gp.repetition_penalty = d.repetition_penalty;
-                    gp.length_penalty =
-                        d.length_penalty.map(|lp| (lp.start_index, lp.decay_factor));
                 }
+                gp.length_penalty =
+                    d.length_penalty.map(|lp| (lp.start_index, lp.decay_factor));
             }
+
             // Stopping Criteria
             if let Some(s) = p.stopping {
                 if s.max_new_tokens != 0 {


### PR DESCRIPTION
It was erroneously tied to the presence of the repetition penalty parameter. So when the repetition penalty wasn't set, the server would get this parameter even though the client sent it to the router.