### PR TITLE
ci: add GIT_COMMIT_HASH build arg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,8 @@ jobs:
         with:
           context: .
           target: server-release
+          build-args: |
+            GIT_COMMIT_HASH=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}
           cache-to: ${{ env.CACHE_TO }}


### PR DESCRIPTION
This build arg is injected into the code and printed at boot up, which is useful to know exactly what version of the code is being executed in a container.
