### PR TITLE
🐛 fix lm_head weight mapping

### DIFF
--- a/server/text_generation_server/inference_engine/tgis_native.py
+++ b/server/text_generation_server/inference_engine/tgis_native.py
@@ -64,7 +64,9 @@ class InferenceEngine(BaseInferenceEngine):
             model_class = BloomForCausalLM
 
         elif model_type == "t5":
-            aliases = {"shared.weight": ["encoder.embed_tokens.weight", "decoder.embed_tokens.weight"]}
+            aliases = {
+                "shared.weight": ["encoder.embed_tokens.weight", "decoder.embed_tokens.weight"], 
+                "lm_head.weight":["decoder.embed_tokens.weight"]}
             from text_generation_server.models.custom_modeling.t5_modeling import T5ForConditionalGeneration
             model_class = T5ForConditionalGeneration
 

--- a/server/text_generation_server/inference_engine/tgis_native.py
+++ b/server/text_generation_server/inference_engine/tgis_native.py
@@ -66,7 +66,8 @@ class InferenceEngine(BaseInferenceEngine):
         elif model_type == "t5":
             aliases = {
                 "shared.weight": ["encoder.embed_tokens.weight", "decoder.embed_tokens.weight"], 
-                "lm_head.weight":["decoder.embed_tokens.weight"]}
+                "lm_head.weight": ["decoder.embed_tokens.weight"],
+            }
             from text_generation_server.models.custom_modeling.t5_modeling import T5ForConditionalGeneration
             model_class = T5ForConditionalGeneration
 


### PR DESCRIPTION
#### Motivation

Fixing an internal issue where `ml6team/keyphrase-generation-t5-small-inspec` and the `t5-small` models were failing due to `RuntimeError: weight lm_head.weight does not exist` error.

<details open>
<summary>Detailed error</summary>

```
Shard 0: Traceback (most recent call last):
Shard 0: 
Shard 0:   File "/opt/tgis/bin/text-generation-server", line 8, in <module>
Shard 0:     sys.exit(app())
Shard 0:              ^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/cli.py", line 75, in serve
Shard 0:     raise e
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/cli.py", line 56, in serve
Shard 0:     server.serve(
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/server.py", line 389, in serve
Shard 0:     asyncio.run(
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/asyncio/runners.py", line 190, in run
Shard 0:     return runner.run(main)
Shard 0:            ^^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/asyncio/runners.py", line 118, in run
Shard 0:     return self._loop.run_until_complete(task)
Shard 0:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
Shard 0:     return future.result()
Shard 0:            ^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/server.py", line 267, in serve_inner
Shard 0:     model = get_model(
Shard 0:             ^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/models/__init__.py", line 129, in get_model
Shard 0:     return Seq2SeqLM(model_name, revision, deployment_framework, dtype, quantize, model_config, max_sequence_length)
Shard 0:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/models/seq2seq_lm.py", line 557, in __init__
Shard 0:     inference_engine = get_inference_engine_class(deployment_framework)(
Shard 0:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/inference_engine/tgis_native.py", line 117, in __init__
Shard 0:     model = model_class(self._config, weights)
Shard 0:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/models/custom_modeling/t5_modeling.py", line 1043, in __init__
Shard 0:     self.lm_head = TensorParallelHead.load(
Shard 0:                    ^^^^^^^^^^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/utils/layers.py", line 219, in load
Shard 0:     weight = weights.get_tensor(f"{prefix}.weight")
Shard 0:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/utils/weights.py", line 69, in get_tensor
Shard 0:     filename, tensor_name = self.get_filename(tensor_name)
Shard 0:                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Shard 0: 
Shard 0:   File "/opt/tgis/lib/python3.11/site-packages/text_generation_server/utils/weights.py", line 56, in get_filename
Shard 0:     raise RuntimeError(f"weight {tensor_name} does not exist")
Shard 0: 
Shard 0: RuntimeError: weight lm_head.weight does not exist
Shard 0: 
2024-03-28T06:02:14.967668Z ERROR text_generation_launcher: Shard 0 failed: ExitStatus(unix_wait_status(256))
2024-03-28T06:02:15.067414Z  INFO text_generation_launcher: Shutting down shards

```
</details>

#### Modifications

We added the `lm_head.weight` alias to the list of known aliases for `t5` type models. (It was discovered within the `metadata` of the tensor file during inspection)

```
"lm_head.weight":["decoder.embed_tokens.weight"]
```

#### Result

Now we're able to launch `t5` based `ml6team/keyphrase-generation-t5-small-inspec` and `t5-small` models using `tgis_native`!
```
DEPLOYMENT_FRAMEWORK=tgis_native MODEL_NAME=ml6team/keyphrase-generation-t5-small-inspec text-generation-launcher
```

