### PR TITLE
Bump fms-extras version to avoid torch 2.3.0 issue

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -30,7 +30,7 @@ onnxruntime-gpu = { version = "^1.17.1", optional = true }
 onnx = { version = "^1.16.0", optional = true }
 einops = "^0.7.0"
 ibm-fms = { version = "^0.0", optional = true }
-fms-extras = { git = "https://github.com/foundation-model-stack/fms-extras", rev = "c983a2989f711bb27ca00314c7c8da5b5891d9ef", optional = true }
+fms-extras = { git = "https://github.com/foundation-model-stack/fms-extras", rev = "d41f8a34c9841aa3c4c59f17b5e7f3cb365f49de", optional = true }
 
 # Explicitly install some transitive dependencies to avoid CVEs
 jinja2 = ">=3.1.3"


### PR DESCRIPTION
#### Motivation

Torch 2.3.0 was released last week and fms-extras was pulling it in as a build dependency, leading to symbol conflicts with torch 2.2.1 (what we are using currently). I've changed the versioning inside fms-extras to ensure this doesn't happen. 

#### Modifications

Just bumping version for fms-extras

#### Result

Resolves ImportErrors that are present with current main:
```
 ImportError: /opt/tgis/lib/python3.11/site-packages/fms_extras/paged_c.cpython-311-x86_64-linux-gnu.so: undefined symbol: _ZN3c104cuda14ExchangeDeviceEa
 ```

#### Related Issues

n/a


