### PR TITLE
fix: check for tokenizer eos_token in ModelInfo response

### DIFF
--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -79,7 +79,7 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
         return generate_pb2.ModelInfoResponse(
             model_type=ModelInfoResponse.ModelType.SEQ2SEQ_LM
                 if isinstance(self.model, Seq2SeqLM) else ModelInfoResponse.ModelType.CAUSAL_LM,
-            eos_token=self.model.config.eos_token_id,
+            eos_token=getattr(self.model.tokenizer, 'model_eos_token_id', self.model.tokenizer.eos_token_id),
             batch_padding=not isinstance(self.model, FlashCausalLM),
             memory_scaling_model=self.memory_scaling_model,
         )


### PR DESCRIPTION
#### Motivation

The model config may not have the `eos_token_id` set as it is an optional field. The `ModelInfo` response from the Server is what the Router uses to determine the EOS token, but it only checks `self.model.config.eos_token_id`. If `config.eos_token_id` is None, the eos token id then defaults to 0.

In most places in the Server code that need the EOS token (eg. [when creating the next token chooser](https://github.com/IBM/text-generation-inference/blob/e87d46215edccba99ecfc97d5d925cc8df926598/server/text_generation_server/models/causal_lm.py#L118)), the check is:
```
getattr(tokenizer, 'model_eos_token_id', tokenizer.eos_token_id)
```
which uses an attribute that is added to the `tokenizer` in model.py if the model config has the eos token ([REF](https://github.com/IBM/text-generation-inference/blob/e87d46215edccba99ecfc97d5d925cc8df926598/server/text_generation_server/models/model.py#L41-L43)) but also falls back to the tokenizer attribute. ModelInfo should do the same.

#### Modifications

Use consistent logic to determine the eos_token_id in ModelInfo as it is in other functions by falling back to the tokenizer's `eos_token_id` attribute if the model config does not have an `eos_token_id`.

#### Result

Fixes the behavior for a model that does not have an eos_token_id configured in its config by using the tokenizer configuration instead.

#### Related Issues

Resolves https://github.com/IBM/text-generation-inference/issues/91
