### PR TITLE
Free blocks in KVCacheManager upon error

### DIFF
--- a/server/text_generation_server/utils/paged.py
+++ b/server/text_generation_server/utils/paged.py
@@ -169,7 +169,12 @@ def prepare_inputs_with_speculation(
         child_sequence_ids_flattened.extend(child_sequence_ids)
 
     # add n_adds tokens to each candidate
-    cache_data = kv_cache_manager.allocate_tokens(num_tokens_per_sequence, child_sequence_ids_flattened)
+    try:
+        cache_data = kv_cache_manager.allocate_tokens(num_tokens_per_sequence, child_sequence_ids_flattened)
+    except:
+        kv_cache_manager.free_sequences(child_sequence_ids_flattened)
+        raise
+
     position_ids = cache_data.position_ids
 
     # Get candidate set of speculations


### PR DESCRIPTION
#### Motivation

We are see pods with spec. decoding getting restarted in BAM due to health checks failing. Upon inspection of the logs, it looks like we are running out of blocks, and never recovering from it. 
#### Modifications

I added a simple check that if something goes wrong when generating a token, we free the blocks associated with that batch. I also had to ensure that the we free the child sequences that get created during speculation if something goes wrong there too.

#### Result

I've verified this allow us to recover from failures related to running out of blocks. Hopefully after this fix, we don't see the inference server getting restarted. 

