### PR TITLE
Fix logic for determining the number of cache blocks

### DIFF
--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -35,6 +35,7 @@ def get_model(
     dtype_str: str,
     quantize: Optional[str],
     max_sequence_length: Optional[int],
+    weight_limit: Optional[int] = None,
 ) -> Model:
     dtype = get_torch_dtype(dtype_str)
     model_path = get_model_path(model_name, revision)
@@ -74,6 +75,7 @@ def get_model(
             dtype, quantize,
             model_config,
             max_sequence_length=max_sequence_length,
+            weight_limit=weight_limit,
         )
 
     if FLASH_ATTENTION:

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -35,7 +35,7 @@ def get_model(
     dtype_str: str,
     quantize: Optional[str],
     max_sequence_length: Optional[int],
-    weight_limit: Optional[int] = None,
+    memory_scaling_model: Optional[int] = None,
 ) -> Model:
     dtype = get_torch_dtype(dtype_str)
     model_path = get_model_path(model_name, revision)
@@ -75,7 +75,7 @@ def get_model(
             dtype, quantize,
             model_config,
             max_sequence_length=max_sequence_length,
-            weight_limit=weight_limit,
+            memory_scaling_model=memory_scaling_model,
         )
 
     if FLASH_ATTENTION:

--- a/server/text_generation_server/models/custom_modeling/paged_llama_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/paged_llama_modeling.py
@@ -434,6 +434,9 @@ class PagedLlamaForCausalLM(torch.nn.Module):
             weights=weights,
         )
 
+    def get_kv_cache_block_size(self, block_size: int) -> int:
+        return block_size * self.model.num_key_value_heads * self.model.head_size * 2
+
     def get_input_embeddings(self) -> nn.Module:
         return self.model.embed_tokens
 

--- a/server/text_generation_server/models/custom_modeling/paged_llama_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/paged_llama_modeling.py
@@ -207,6 +207,7 @@ class PagedLlamaAttention(torch.nn.Module):
         self.num_key_value_heads = (
             config.num_key_value_heads // weights.process_group.size()
         )
+
         if config.num_attention_heads != config.num_key_value_heads:
             self.query_key_value = _load_gqa(config, prefix, weights)
         else:
@@ -239,7 +240,6 @@ class PagedLlamaAttention(torch.nn.Module):
             ],
             dim=1,
         )
-
         query = query.view(-1, self.num_heads, self.head_size)
         kv = kv.view(-1, 2, self.num_key_value_heads, self.head_size)
         key = torch.select(kv, dim=1, index=0)

--- a/server/text_generation_server/models/custom_modeling/paged_llama_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/paged_llama_modeling.py
@@ -207,7 +207,6 @@ class PagedLlamaAttention(torch.nn.Module):
         self.num_key_value_heads = (
             config.num_key_value_heads // weights.process_group.size()
         )
-
         if config.num_attention_heads != config.num_key_value_heads:
             self.query_key_value = _load_gqa(config, prefix, weights)
         else:
@@ -240,6 +239,7 @@ class PagedLlamaAttention(torch.nn.Module):
             ],
             dim=1,
         )
+
         query = query.view(-1, self.num_heads, self.head_size)
         kv = kv.view(-1, 2, self.num_key_value_heads, self.head_size)
         key = torch.select(kv, dim=1, index=0)

--- a/server/text_generation_server/models/custom_modeling/paged_santacoder_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/paged_santacoder_modeling.py
@@ -407,6 +407,9 @@ class PagedSantacoderForCausalLM(nn.Module):
             config, prefix="transformer.wte", weights=weights
         )
 
+    def get_kv_cache_block_size(self, block_size: int) -> int:
+        return block_size * self.model.head_size * 2
+
     def get_input_embeddings(self) -> nn.Module:
         return self.transformer.wte
 

--- a/server/text_generation_server/models/custom_modeling/paged_santacoder_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/paged_santacoder_modeling.py
@@ -408,7 +408,7 @@ class PagedSantacoderForCausalLM(nn.Module):
         )
 
     def get_kv_cache_block_size(self, block_size: int) -> int:
-        return block_size * self.model.head_size * 2
+        return block_size * self.transformer.head_size * 2
 
     def get_input_embeddings(self) -> nn.Module:
         return self.transformer.wte

--- a/server/text_generation_server/models/paged_causal_lm.py
+++ b/server/text_generation_server/models/paged_causal_lm.py
@@ -310,7 +310,7 @@ class PagedCausalLM(Model):
         if KV_CACHE_MANAGER_NUM_GPU_BLOCKS is not None:
             total_num_gpu_blocks = int(KV_CACHE_MANAGER_NUM_GPU_BLOCKS)
         else:
-            print("[tpa] weight_limit: ", memory_scaling_model.weight_limit)
+            print("[tpa] free_memory: ", memory_scaling_model.free_memory)
             print("[tpa] self.model.model.num_key_value_heads: ", self.model.model.num_key_value_heads)
             print("[tpa] self.model.model.head_size: ", self.model.model.head_size)
             kv_cache_block_size = block_size * self.model.model.num_key_value_heads * self.model.model.head_size * 2
@@ -318,9 +318,9 @@ class PagedCausalLM(Model):
             dtype_size = torch.tensor([], dtype=dtype).element_size()
             cache_block_size = dtype_size * total_size
 
-            max_coef = max(memory_scaling_model.linear_fit_params[0], memory_scaling_model.next_token_params[1])
+            max_coef = 0.5 * (memory_scaling_model.linear_fit_params[0] + memory_scaling_model.next_token_params[1])
             cache_block_ratio = cache_block_size / block_size / max_coef
-            total_num_gpu_blocks = int(0.5 * cache_block_ratio * memory_scaling_model.weight_limit // cache_block_size)
+            total_num_gpu_blocks = int(cache_block_ratio * memory_scaling_model.free_memory // cache_block_size)
 
             print("[tpa] cache_block_ratio: ", cache_block_ratio)
 

--- a/server/text_generation_server/models/paged_causal_lm.py
+++ b/server/text_generation_server/models/paged_causal_lm.py
@@ -310,7 +310,7 @@ class PagedCausalLM(Model):
         if KV_CACHE_MANAGER_NUM_GPU_BLOCKS is not None:
             total_num_gpu_blocks = int(KV_CACHE_MANAGER_NUM_GPU_BLOCKS)
         else:
-            # Firstly, let's compute the size of a cache in bytes
+            # Firstly, let's compute the size of a cache block in bytes
             kv_cache_block_size = self.model.get_kv_cache_block_size(block_size)
             total_size = model_config.num_hidden_layers * kv_cache_block_size
             dtype_size = torch.tensor([], dtype=dtype).element_size()

--- a/server/text_generation_server/models/paged_causal_lm.py
+++ b/server/text_generation_server/models/paged_causal_lm.py
@@ -438,6 +438,7 @@ class PagedCausalLM(Model):
             )
         except:
             # if something goes wrong during forward, we still need to set the sequence ids
+            #TODO it would be better to fix the forward method to avoid possibility of partial failures
             batch.sequence_ids = cache_data.sequence_ids
             raise
         t_forward_ns = time.time_ns()-t0

--- a/server/text_generation_server/models/paged_causal_lm.py
+++ b/server/text_generation_server/models/paged_causal_lm.py
@@ -318,8 +318,8 @@ class PagedCausalLM(Model):
             dtype_size = torch.tensor([], dtype=dtype).element_size()
             cache_block_size = dtype_size * total_size
 
-            max_coef = 0.5 * (memory_scaling_model.linear_fit_params[0] + memory_scaling_model.next_token_params[1])
-            cache_block_ratio = cache_block_size / block_size / max_coef
+            #max_coef = 0.5 * (memory_scaling_model.linear_fit_params[0] + memory_scaling_model.next_token_params[1])
+            cache_block_ratio = cache_block_size / block_size / memory_scaling_model.next_token_params[1]
             total_num_gpu_blocks = int(cache_block_ratio * memory_scaling_model.free_memory // cache_block_size)
 
             print("[tpa] cache_block_ratio: ", cache_block_ratio)

--- a/server/text_generation_server/models/paged_causal_lm.py
+++ b/server/text_generation_server/models/paged_causal_lm.py
@@ -275,7 +275,7 @@ class PagedCausalLM(Model):
         quantize: Optional[str],
         model_config: Union[Any] = None,
         max_sequence_length: Optional[int] = None,
-        weight_limit: Optional[int] = None,
+        memory_scaling_model: Optional["MemoryScalingModel"] = None,
     ):
         model_path = get_model_path(model_name, revision)
 
@@ -310,14 +310,20 @@ class PagedCausalLM(Model):
         if KV_CACHE_MANAGER_NUM_GPU_BLOCKS is not None:
             total_num_gpu_blocks = int(KV_CACHE_MANAGER_NUM_GPU_BLOCKS)
         else:
-            print("[tpa] weight_limit: ", weight_limit)
+            print("[tpa] weight_limit: ", memory_scaling_model.weight_limit)
             print("[tpa] self.model.model.num_key_value_heads: ", self.model.model.num_key_value_heads)
             print("[tpa] self.model.model.head_size: ", self.model.model.head_size)
             kv_cache_block_size = block_size * self.model.model.num_key_value_heads * self.model.model.head_size * 2
             total_size = model_config.num_hidden_layers * kv_cache_block_size
             dtype_size = torch.tensor([], dtype=dtype).element_size()
             cache_block_size = dtype_size * total_size
-            total_num_gpu_blocks = int(weight_limit // cache_block_size)
+
+            max_coef = max(memory_scaling_model.linear_fit_params[0], memory_scaling_model.next_token_params[1])
+            cache_block_ratio = cache_block_size / block_size / max_coef
+            total_num_gpu_blocks = int(0.5 * cache_block_ratio * memory_scaling_model.weight_limit // cache_block_size)
+
+            print("[tpa] cache_block_ratio: ", cache_block_ratio)
+
 
         self.kv_cache_manager = PagedKVCacheManager(
             model_config.num_hidden_layers,

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -46,6 +46,7 @@ def log_rpc_handler_errors(func):
             # raised during handling of requests.
             raise
         except torch.cuda.OutOfMemoryError as e:
+            print("HELLO i'm in the error handling: ", e)
             context = kwargs.get("context", None) or args[-1]
             logging.exception(f"{func.__name__} caused GPU OOM error")
             await context.abort(StatusCode.RESOURCE_EXHAUSTED, str(e))
@@ -281,8 +282,9 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
             ]
         else:
             return
-        print("freeing sequence ids: ", sequence_ids_to_free)
-        self.model.kv_cache_manager.free_sequences(sequence_ids_to_free, recursive=True)
+        if sequence_ids_to_free is not None:
+            print("freeing sequence ids: ", sequence_ids_to_free)
+            self.model.kv_cache_manager.free_sequences(sequence_ids_to_free, recursive=True)
 
 
 def serve(

--- a/server/text_generation_server/utils/paged.py
+++ b/server/text_generation_server/utils/paged.py
@@ -5,12 +5,37 @@ import torch
 
 from fms_extras.models.speculator import flatten_batch, apply_index_map
 
+# HF name or path to speculator model (None means no speculation will be used)
+SPECULATOR_NAME = os.getenv("SPECULATOR_NAME", None)
+
+# speculator revision
+SPECULATOR_REVISION = os.getenv("SPECULATOR_REVISION", None)
+
 # number of candidates during speculation
 SPECULATOR_N_CANDIDATES = os.getenv("SPECULATOR_N_CANDIDATES", None)
 
 # number of candidates per head
 SPECULATOR_TOP_K_TOKENS_PER_HEAD = os.getenv("SPECULATOR_TOP_K_TOKENS_PER_HEAD", None)
 
+def load_speculator(device, dtype):
+
+    if SPECULATOR_NAME is not None:
+        from fms_extras.models.hf.modeling_mlp_speculator import MLPSpeculatorPreTrainedModel
+        from text_generation_server.utils.hub import get_model_path
+        from text_generation_server.utils import print_rank_n
+        speculator_model_path = get_model_path(SPECULATOR_NAME, SPECULATOR_REVISION)
+        print_rank_n(f"Loading speculator model from: {speculator_model_path}")
+        kwargs = {
+            "pretrained_model_name_or_path": speculator_model_path,
+            "local_files_only": True,
+            "torch_dtype": dtype,
+        }
+        with device:
+            speculator = MLPSpeculatorPreTrainedModel.from_pretrained(**kwargs)
+            speculator.to(device=device)
+        return speculator
+    else:
+        return None
 
 def fit_memory_scaling_model(
     model_name: str,
@@ -37,6 +62,8 @@ def fit_memory_scaling_model(
     model = get_model(
         model_name, revision, deployment_framework, dtype_str, quantize, max_sequence_length
     )
+
+    speculator = load_speculator(model.device, model.dtype)
 
     memory_scaling_model = Estimator.build_from_env(
         model,
@@ -169,12 +196,7 @@ def prepare_inputs_with_speculation(
         child_sequence_ids_flattened.extend(child_sequence_ids)
 
     # add n_adds tokens to each candidate
-    try:
-        cache_data = kv_cache_manager.allocate_tokens(num_tokens_per_sequence, child_sequence_ids_flattened)
-    except:
-        kv_cache_manager.free_sequences(child_sequence_ids_flattened)
-        raise
-
+    cache_data = kv_cache_manager.allocate_tokens(num_tokens_per_sequence, child_sequence_ids_flattened)
     position_ids = cache_data.position_ids
 
     # Get candidate set of speculations

--- a/server/text_generation_server/utils/paged.py
+++ b/server/text_generation_server/utils/paged.py
@@ -196,7 +196,12 @@ def prepare_inputs_with_speculation(
         child_sequence_ids_flattened.extend(child_sequence_ids)
 
     # add n_adds tokens to each candidate
-    cache_data = kv_cache_manager.allocate_tokens(num_tokens_per_sequence, child_sequence_ids_flattened)
+    try:
+        cache_data = kv_cache_manager.allocate_tokens(num_tokens_per_sequence, child_sequence_ids_flattened)
+    except:
+        kv_cache_manager.free_sequences(child_sequence_ids_flattened)
+        raise
+
     position_ids = cache_data.position_ids
 
     # Get candidate set of speculations


### PR DESCRIPTION
#### Motivation

When we deploy spec decoding in prod., we are frequently seeing the servers running out of free blocks. We have determined that this is due to two issues:
1. The constraint on `SPECULATOR_MAX_BATCH_SIZE` is not enough to avoid running into memory pressure due to speculation - we need to able ensure that we do not speculate on batches that may have a small "size" but very large weight. 
2. The computation of the number of blocks is very wrong in most cases. 

#### Modifications

1. I have introduced an additional constraint that says we should only speculate on batches with weight up to 75% of the weight limit. This should ensure that we never speculate when we are close to the memory limits.
2. I have written new code to calculate the number of KV cache blocks. This calculation uses the memory scaling coefficients that we have learned at startup. In particular, it uses to the learned coefficients to figure out what % of the memory capacity needs to be set aside for cache blocks. 
3. In the above calculation, I use the next token coefficient, rather than the prefill coefficient, since typically during next token phase the KV cache blocks comprise a relatively large percentage of the total memory consumption and we need to be able to handle this worst-case. However, this means that during prefill steps, we may not have enough memory leftover to store the auxiliary data structures we need for a forward pass. There isn't really a clean way to handle this other than re-writing the router logic to be block-aware, but what we can do is recommend to the user that they should increase the batch safety margin to a certain level to ensure that prefills will not run OOM. I've added a print statement to provide this guidance.  
4. I now load the speculator before learning the memory scaling model since we also need to take that into account when measuring the amount of free memory. 

#### Result

These changes, together with setting the `BATCH_SAFETY_MARGIN=35`, seems to result in robust behaviour for both `llama3-8b` and `granite-20b`. We no longer need to manually set the number of KV cache blocks in the latter case. 

#### Related Issues

n/a
