### PR TITLE
use fastsafetensors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -319,6 +319,12 @@ COPY --from=router-builder /usr/local/cargo/bin/text-generation-router /usr/loca
 # Install launcher
 COPY --from=launcher-builder /usr/local/cargo/bin/text-generation-launcher /usr/local/bin/text-generation-launcher
 
+# Install cufile.so, libnuma.so, and fastsafetensors
+RUN dnf config-manager \
+       --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo \
+    && dnf install -y libcufile-12-1 numactl-libs
+RUN pip install -v fastsafetensors==0.1.0 --no-cache-dir
+
 ENV PORT=3000 \
     GRPC_PORT=8033 \
     HOME=/home/tgis


### PR DESCRIPTION
#### Motivation

Fastsafetensors (https://github.com/foundation-model-stack/fastsafetensors/) significantly reduces model loading time of .safetensors files on NVMe SSDs parallelizing file copies for maximum throughput, and offloading tensor sharding and type conversions to GPUs. Additionally, Fastsafetensors supports GPU Direct Storage (GDS) to further optimize cold startups from NVMe SSDs.

For instance, in a comparison between Fastsafetensors and the current loader, the cold startup time of bigscience/bloom at 4 NVMe and 8 A100 GPUs was reduced from 95 seconds to 28.4 seconds with Fastsafetensors. Similarly, the hot startup time (loading files at page cache) of llama-2-13b-chat was reduced from 8.7 seconds to 4.7 seconds with a single GPU using Fastsafetensors

#### Modifications

Fastsafetensors is provided as a PyPi package. It includes a compatible Weight class to load weights (`fastsafetensors.connectors.tgis_weights.Weight`). I modified tgis_native.py to replace the Weight class with environmental variables since I do not want to largely modify codes to add fastsafetensors configurations. Currently, the class has `get_tensor` and `get_sahrded` and others except for quantization.

I added two tuning knobs for the number of copy threads and bounce buffer sizes. They should be changed according to the available CPUs in a NUMA node and the size of the CPU cache, especially in hot startups, i.e., when files are on DRAM. My experiences of using Icelake servers implied that the size of bounce buffers should be L2 cache size (160MB in this case).

The package depends on libcufile.so and libnuma.so. So, we need to modify Dockerfile to add them in the final image.

For tensor parallel inference, Fastsafetensors first loads multiple files in a round-robin fashion for multiple GPUs. It then reuses torch.distributed methods to obtain or shard weights from one of the ranks. As a result, every Weight method, including `get_tensor`, may load tensors from a remote rank. This requires ensuring that both a sender rank and a getter rank are invoked to get a tensor, unlike before. While most cases do not require modifying existing classes, `TensorParallelRowLinear` has an if-else statement for rank 0's `get_tensor`. To address this, I changed `get_tensor` to `push_tensor`, which sets a sender and receiver rank (while other ranks do nothing).


#### Result

As described in the Motivation section, we observed speedups in both cold and hot startups of TGIS with various models. So far, I have tested with falcon-40b, bloom, and llama.

However, GDS limits the available optimization using `PYTORCH_CUDA_ALLOC_CONF`. Currently, we cannot set it to "expandable_segments:True" to use cuMemmap, which is not available with peer-to-peer transfers.

Additionally, using tensor parallel with Fastsafetensors can cause deadlocks at memory estimation. In my experiments, I always set `ESTIMATE_MEMORY=off` to avoid this issue. This is because Fastsafetensors can have different GPU memory consumptions among ranks, which can confuse the out-of-memory detection logic. Some ranks may continue running forward() while others do not, which fail to call `get_tensor` and others in the same order at every rank. The memory estimation seems to assume that every GPU consumes GPU memory evenly, which is not always the case with Fastsafetensors.

#### Related Issues

NA

